### PR TITLE
Update version number for CodeArtifact deploy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.rst') as f:
 
 setup(
     name='Flask-WTF',
-    version='0.13.1',
+    version='0.13.1.post1',
     url='https://github.com/lepture/flask-wtf',
     license='BSD',
     author='Dan Jacob',


### PR DESCRIPTION
We want to deploy this forked version of Flask-WTF to CodeArtifact without shadowing external versions. In preparation for that, I've appended to the version number in a way which should avoid shadowing.