### PR TITLE
Remove safe_str_cmp from csrf.py

### DIFF
--- a/flask_wtf/csrf.py
+++ b/flask_wtf/csrf.py
@@ -109,6 +109,8 @@ def validate_csrf(data, secret_key=None, time_limit=None, token_key='csrf_token'
         digestmod=hashlib.sha1
     ).hexdigest()
 
+    # Originally used werkzeug.security.safe_str_cmp, which was removed in Werkzeug 2.1
+    # https://github.com/pallets/werkzeug/pull/2276/files#diff-97d9d852b7ac5531335c7fdcb2b7e445c9d1d2993d02d56f129202fcdfcafbf3L103-L120
     return hmac.compare_digest(hmac_compare, hmac_csrf)
 
 

--- a/flask_wtf/csrf.py
+++ b/flask_wtf/csrf.py
@@ -14,7 +14,6 @@ import hashlib
 import time
 from flask import Blueprint
 from flask import current_app, session, request, abort
-from werkzeug.security import safe_str_cmp
 from ._compat import to_bytes, string_types
 try:
     from urlparse import urlparse
@@ -110,7 +109,7 @@ def validate_csrf(data, secret_key=None, time_limit=None, token_key='csrf_token'
         digestmod=hashlib.sha1
     ).hexdigest()
 
-    return safe_str_cmp(hmac_compare, hmac_csrf)
+    return hmac.compare_digest(hmac_compare, hmac_csrf)
 
 
 class CsrfProtect(object):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.rst') as f:
 
 setup(
     name='benchling-flask-wtf',
-    version='0.13.1.post1',
+    version='0.13.1.post2',
     url='https://github.com/benchling/flask-wtf',
     license='BSD',
     author='Dan Jacob',


### PR DESCRIPTION
We need to upgrade werkzeug in aurelia, and the latest versions of werkzeug no longer contain the safe_str_cmp function.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #<issue number>

<!--
Ensure each step for contributing is complete by adding an "x" to each
box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `docs/changes.rst` summarizing the change and linking to the issue. Add `.. versionchanged::` entries in any relevant code docs.
