### PR TITLE
Make compatible with Jinja2 3.1.2

### DIFF
--- a/flask_wtf/form.py
+++ b/flask_wtf/form.py
@@ -3,7 +3,9 @@ import warnings
 
 import werkzeug.datastructures
 from flask import request, session, current_app
-from jinja2 import Markup
+# Accommodates a newer version of jinja2, see
+# https://stackoverflow.com/questions/71645272/importerror-cannot-import-name-markup-from-jinja2
+from jinja2.utils.markupsafe import Markup
 from wtforms.compat import with_metaclass
 from wtforms.ext.csrf.form import SecureForm
 from wtforms.form import FormMeta

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.rst') as f:
 
 setup(
     name='benchling-flask-wtf',
-    version='0.13.1.post2',
+    version='0.13.1.post3',
     url='https://github.com/benchling/flask-wtf',
     license='BSD',
     author='Dan Jacob',


### PR DESCRIPTION
Markup was moved from jinja2 to jnija2.utils.markupsafe in version 3.0.1.

<!--
Link to relevant issues or previous PRs, one per line. Use "fixes" to
automatically close an issue.
-->

- fixes #<issue number>

<!--
Ensure each step for contributing is complete by adding an "x" to each
box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [ ] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [ ] Add or update relevant docs, in the docs folder and in code.
- [ ] Add an entry in `docs/changes.rst` summarizing the change and linking to the issue. Add `.. versionchanged::` entries in any relevant code docs.
