### PR TITLE
eng: Use urllib.parse.urleencode for werkzeug >3

### DIFF
--- a/flask_wtf/recaptcha/validators.py
+++ b/flask_wtf/recaptcha/validators.py
@@ -6,7 +6,7 @@ except ImportError:
 
 from flask import request, current_app
 from wtforms import ValidationError
-from werkzeug.urls import url_encode
+from urllib.parse import urlencode
 from .._compat import to_bytes, to_unicode
 import json
 
@@ -54,7 +54,7 @@ class Recaptcha(object):
         except KeyError:
             raise RuntimeError("No RECAPTCHA_PRIVATE_KEY config set")
 
-        data = url_encode({
+        data = urlencode({
             'secret':     private_key,
             'remoteip':   remote_addr,
             'response':   response

--- a/flask_wtf/recaptcha/widgets.py
+++ b/flask_wtf/recaptcha/widgets.py
@@ -2,7 +2,7 @@
 
 from flask import current_app, Markup
 from flask import json
-from werkzeug.urls import url_encode
+from urllib.parse import urlencode
 
 JSONEncoder = json.JSONEncoder
 
@@ -25,7 +25,7 @@ class RecaptchaWidget(object):
         params = current_app.config.get('RECAPTCHA_PARAMETERS')
         script = RECAPTCHA_SCRIPT
         if params:
-            script += u'?' + url_encode(params)
+            script += u'?' + urlencode(params)
 
         attrs = current_app.config.get('RECAPTCHA_DATA_ATTRS', {})
         attrs['sitekey'] = public_key

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.rst') as f:
 
 setup(
     name='benchling-flask-wtf',
-    version='0.13.1.post5',
+    version='0.13.1.post6',
     url='https://github.com/benchling/flask-wtf',
     license='BSD',
     author='Dan Jacob',


### PR DESCRIPTION
Replaces the deprecate `werkzeug.urls.url_encode` with `urllib.parse.urlencode`. From their changelog:

> Deprecate the werkzeug.urls module, except for the uri_to_iri and iri_to_uri functions. Use the urllib.parse library instead. 2600

https://github.com/pallets/werkzeug/blob/d6c2fe14682c95ba08921d3474f4f6527d471fe2/CHANGES.rst#version-230


This should let us upgrade to werkzeug == 3.0.1
